### PR TITLE
Patch colors for personal use

### DIFF
--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -128,17 +128,17 @@ impl Colours {
 
             perms: Permissions {
                 user_read:           Yellow.normal(),
-                user_write:          Yellow.normal(),
-                user_execute_file:   Green.bold(),
-                user_execute_other:  Green.bold(),
+                user_write:          Cyan.normal(),
+                user_execute_file:   Purple.normal(),
+                user_execute_other:  Purple.normal(),
 
                 group_read:          Yellow.normal(),
-                group_write:         Red.normal(),
-                group_execute:       Green.normal(),
+                group_write:         Cyan.normal(),
+                group_execute:       Purple.normal(),
 
                 other_read:          Yellow.normal(),
-                other_write:         Red.normal(),
-                other_execute:       Green.normal(),
+                other_write:         Cyan.normal(),
+                other_execute:       Purple.normal(),
 
                 special_user_file:   Purple.normal(),
                 special_other:       Purple.normal(),

--- a/src/style/colours.rs
+++ b/src/style/colours.rs
@@ -127,9 +127,9 @@ impl Colours {
             },
 
             perms: Permissions {
-                user_read:           Yellow.bold(),
-                user_write:          Red.bold(),
-                user_execute_file:   Green.bold().underline(),
+                user_read:           Yellow.normal(),
+                user_write:          Yellow.normal(),
+                user_execute_file:   Green.bold(),
                 user_execute_other:  Green.bold(),
 
                 group_read:          Yellow.normal(),
@@ -147,10 +147,10 @@ impl Colours {
             },
 
             size: Size {
-                numbers:  Green.bold(),
+                numbers:  Green.normal(),
                 unit:     Green.normal(),
 
-                major:  Green.bold(),
+                major:  Green.normal(),
                 minor:  Green.normal(),
 
                 scale_byte: Fixed(118).normal(),
@@ -161,15 +161,15 @@ impl Colours {
             },
 
             users: Users {
-                user_you:           Yellow.bold(),
+                user_you:           Cyan.normal(),
                 user_someone_else:  Style::default(),
                 group_yours:        Yellow.bold(),
                 group_not_yours:    Style::default(),
             },
 
             links: Links {
-                normal:          Red.bold(),
-                multi_link_file: Red.on(Yellow),
+                normal:          Cyan.bold(),
+                multi_link_file: Cyan.on(Yellow),
             },
 
             git: Git {
@@ -190,7 +190,7 @@ impl Colours {
             symlink_path:         Cyan.normal(),
             control_char:         Red.normal(),
             broken_symlink:       Red.normal(),
-            broken_path_overlay:  Style::default().underline(),
+            broken_path_overlay:  Style::default(),
         }
     }
 }


### PR DESCRIPTION
<img width="445" alt="Screenshot 2020-01-10 14 53 12" src="https://user-images.githubusercontent.com/21333876/72129258-ed82e900-33b8-11ea-9dc1-42db34d629e9.png">


This is a workaround until the original `exa` supports color configuration for users.